### PR TITLE
Fixes to AddFriend flow when the user added is a pending request.

### DIFF
--- a/Assets/UGSSamples/FriendsSample/Scripts/Common/Managers/RelationshipsManager.cs
+++ b/Assets/UGSSamples/FriendsSample/Scripts/Common/Managers/RelationshipsManager.cs
@@ -148,9 +148,18 @@ namespace Unity.Services.Samples.Friends
         {
             var success = await SendFriendRequest(name);
             if (success)
+            {
                 m_AddFriendView.FriendRequestSuccess();
+                if (m_RequestsEntryDatas.Find(entry => entry.Name == name) != null)
+                {
+                    RefreshFriends();
+                    RefreshRequests();
+                }
+            }
             else
+            {
                 m_AddFriendView.FriendRequestFailed();
+            }
         }
 
         void RefreshFriends()
@@ -216,7 +225,7 @@ namespace Unity.Services.Samples.Friends
                 //We add the friend by name in this sample but you can also add a friend by ID using AddFriendAsync
                 var relationship = await FriendsService.Instance.AddFriendByNameAsync(playerName);
                 Debug.Log($"Friend request sent to {playerName}.");
-                return relationship.Type == RelationshipType.FRIEND_REQUEST;
+                return relationship.Type == RelationshipType.FRIEND_REQUEST || relationship.Type == RelationshipType.FRIEND;
             }
             catch (RelationshipsServiceException e)
             {


### PR DESCRIPTION
Currently
1) If you add a user via the AddFriendPopup who is in your pending requests it will display an error and
2) not remove the Request nor show them as a friend. 

If you add a user who is also a pending requests, no longer show an error in the add friend popup. Error was caused because SendFriendRequest only considers RelationshipType FRIEND_REQUEST a valid type but if there is a pending request the RelationshipType will be come back as FRIEND

The change to AddFriendAsync will check if the users name matches one in the request list and if a match is found it will refresh both Requests and Friends to update the UI accordingly.

